### PR TITLE
Cron

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ## [Unreleased]
 ### Added
 - Ability to define custom valid IPs to access webhook.
+- Execute commands via cron, using `cron` action and `g` parameter.
 ### Changed
 - Remodelled the config array to a more flexible structure.
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -40,18 +40,20 @@ and then run `composer update`
 
 What use would this library be if you couldn't perform any actions?!
 
-There are 4 parameters available to get things rolling:
+There are a few parameters available to get things rolling:
 
 | Parameter | Description |
 | --------- | ----------- |
 | s         | **s**ecret: This is a special secret value defined in the main `manager.php` file. |
 |           | This parameter is required to call the script via browser! |
-| a         | **a**ction: The actual action to perform. (handle (default), set, unset, reset) |
-|           | **handle** executes the `getUpdates` method; **set** / **unset** / **reset** the Webhook. |
+| a         | **a**ction: The actual action to perform. (handle (default), cron, set, unset, reset) |
+|           | **handle** executes the `getUpdates` method; **cron** executes cron commands; **set** / **unset** / **reset** the webhook. |
 | l         | **l**oop: Number of seconds to loop the script for (used for getUpdates method). |
 |           | This would be used mainly via CLI, to continually get updates for a certain period. |
-| i         | **i**nterval: Number of seconds to wait between getUpdates requests (used for getUpdates method, default: 2). |
+| i         | **i**nterval: Number of seconds to wait between getUpdates requests (used for getUpdates method, default is 2). |
 |           | This would be used mainly via CLI, to continually get updates for a certain period, every **i** seconds. |
+| g         | **g**roup: Commands group for cron (only used together with `cron` action, default group is `default`). |
+|           | Define which group of commands to execute via cron. |
 
 #### via browser
 
@@ -102,7 +104,7 @@ Handle updates for 30 seconds, fetching every 5 seconds:
 You can name this file whatever you like, it just has to be somewhere inside your PHP project (preferably in the root folder to make things easier).
 (Let's assume our file is called `manager.php`)
 
-Let's start off with a simple example that uses the Webhook method:
+Let's start off with a simple example that uses the webhook method:
 ```php
 <?php
 
@@ -253,6 +255,24 @@ $bot = new BotManager([
         'options' => [
             // (float) Custom timeout for requests.
             'timeout' => 3,
+        ],
+    ],
+
+    // (array) All options that have to do with cron.
+    'cron'             => [
+        // (array) List of groups that contain the commands to execute.
+        'groups' => [
+            // Each group has a name and array of commands.
+            // When no group is defined, the default group gets executed.
+            'default'     => [
+                '/default_cron_command',
+            ],
+            'maintenance' => [
+                '/db_cleanup',
+                '/db_repair',
+                '/log_rotate',
+                '/message_admins Maintenance completed',
+            ],
         ],
     ],
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ There are a few parameters available to get things rolling:
 | i         | **i**nterval: Number of seconds to wait between getUpdates requests (used for getUpdates method, default is 2). |
 |           | This would be used mainly via CLI, to continually get updates for a certain period, every **i** seconds. |
 | g         | **g**roup: Commands group for cron (only used together with `cron` action, default group is `default`). |
-|           | Define which group of commands to execute via cron. |
+|           | Define which group of commands to execute via cron. Can be a comma separated list of groups. |
 
 #### via browser
 
@@ -75,6 +75,12 @@ Handle updates once:
 
 Handle updates for 30 seconds, fetching every 5 seconds:
 - `http://example.com/manager.php?s=super_secret&l=30&i=5`
+
+**cron**
+
+Execute commands via cron:
+- `http://example.com/manager.php?s=super_secret&a=cron&g=maintenance` or multiple groups
+- `http://example.com/manager.php?s=super_secret&a=cron&g=maintenance,cleanup`
 
 #### via CLI
 
@@ -98,6 +104,12 @@ Handle updates once:
 
 Handle updates for 30 seconds, fetching every 5 seconds:
 - `$ php manager.php l=30 i=5`
+
+**cron**
+
+Execute commands via cron:
+- `$ php manager.php a=cron g=maintenance` or multiple groups
+- `$ php manager.php a=cron g=maintenance,cleanup`
 
 ### Create the manager PHP file
 

--- a/src/Action.php
+++ b/src/Action.php
@@ -22,6 +22,7 @@ class Action
         'unset',
         'reset',
         'handle',
+        'cron',
     ];
 
     /**

--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -508,6 +508,7 @@ class BotManager
      */
     public function isValidRequest(): bool
     {
+        // If we're running from CLI, requests are always valid, unless we're running the tests.
         if ((!self::inTest() && 'cli' === PHP_SAPI) || false === $this->params->getBotParam('validate_request')) {
             return true;
         }

--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -351,8 +351,12 @@ class BotManager
      */
     public function handleCron(): self
     {
-        $group = $this->params->getScriptParam('g', 'default');
-        $commands = $this->params->getBotParam('cron.groups.' . $group, []);
+        $groups = explode(',', $this->params->getScriptParam('g', 'default'));
+
+        $commands = [];
+        foreach ($groups as $group) {
+            $commands = array_merge($commands, $this->params->getBotParam('cron.groups.' . $group, []));
+        }
         $this->telegram->runCommands($commands);
 
         return $this;

--- a/src/Params.php
+++ b/src/Params.php
@@ -18,10 +18,11 @@ class Params
      * @var array List of valid script parameters.
      */
     private static $valid_script_params = [
-        's',
-        'a',
-        'l',
-        'i',
+        's', // secret
+        'a', // action
+        'l', // loop
+        'i', // interval
+        'g', // group (for cron)
     ];
 
     /**
@@ -47,8 +48,8 @@ class Params
         'paths',
         'commands',
         'botan',
-        'custom_input',
         'cron',
+        'custom_input',
     ];
 
     /**

--- a/tests/TelegramBotManager/Tests/ActionTest.php
+++ b/tests/TelegramBotManager/Tests/ActionTest.php
@@ -20,6 +20,7 @@ class ActionTest extends \PHPUnit\Framework\TestCase
         self::assertEquals('unset', (new Action('unset'))->getAction());
         self::assertEquals('reset', (new Action('reset'))->getAction());
         self::assertEquals('handle', (new Action('handle'))->getAction());
+        self::assertEquals('cron', (new Action('cron'))->getAction());
     }
 
     /**

--- a/tests/TelegramBotManager/Tests/BotManagerTest.php
+++ b/tests/TelegramBotManager/Tests/BotManagerTest.php
@@ -44,6 +44,14 @@ class BotManagerTest extends \PHPUnit\Framework\TestCase
         ];
     }
 
+    /**
+     * To test the live commands, act as if we're being called by Telegram.
+     */
+    protected function makeRequestValid()
+    {
+        $_SERVER['REMOTE_ADDR'] = '149.154.167.197';
+    }
+
     public function testSetParameters()
     {
         $botManager = new BotManager(array_merge(ParamsTest::$demo_vital_params, [
@@ -239,9 +247,11 @@ class BotManagerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group live
+     * @runInSeparateProcess
      */
     public function testDeleteWebhookViaRunLiveBot()
     {
+        $this->makeRequestValid();
         $_GET       = ['a' => 'unset'];
         $botManager = new BotManager(array_merge(self::$live_params, [
             'webhook' => ['url' => 'https://example.com/hook.php'],
@@ -438,9 +448,11 @@ class BotManagerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group live
+     * @runInSeparateProcess
      */
     public function testGetUpdatesLiveBot()
     {
+        $this->makeRequestValid();
         $botManager = new BotManager(self::$live_params);
         $output     = $botManager->run()->getOutput();
         self::assertContains('Updates processed: 0', $output);
@@ -448,10 +460,12 @@ class BotManagerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @group live
+     * @runInSeparateProcess
      */
     public function testGetUpdatesLoopLiveBot()
     {
-        // Webhook must NOT be set for this to work!
+        $this->makeRequestValid();
+        // Webhook MUST NOT be set for this to work!
         $this->testDeleteWebhookViaRunLiveBot();
 
         // Looping for 5 seconds should be enough to get a result.

--- a/tests/TelegramBotManager/Tests/ParamsTest.php
+++ b/tests/TelegramBotManager/Tests/ParamsTest.php
@@ -63,7 +63,19 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
         'botan'            => [
             'token' => 'botan_12345',
         ],
-        'custom_input'     => '{"some":"raw", "json":"update"}',
+        'cron'             => [
+            'groups' => [
+                'default'     => [
+                    '/default_cron_command',
+                ],
+                'maintenance' => [
+                    '/db_cleanup',
+                    '/db_repair',
+                    '/log_rotate',
+                ],
+            ],
+        ],
+        'custom_input' => '{"some":"raw", "json":"update"}',
     ];
 
     public function setUp()


### PR DESCRIPTION
Allow execution of cron commands, which are defined in groups.

```php
'cron' => [
    'groups' => [
        'default'     => [
            '/default_cron_command',
        ],
        'maintenance' => [
            '/db_cleanup',
            '/db_repair',
            '/log_rotate',
        ],
    ],
],
```

Default command group:
`$ php manager.php a=cron`

Single group:
`$ php manager.php a=cron g=maintenance`

Also allows multiple groups to be called in 1 go:
`$ php manager.php a=cron g=maintenance,cleanup,whatever`

(note: This PR builds on top of #18)