### PR TITLE
Initialise loggers before anything else, to allow logging of all errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 ### Deprecated
 ### Removed
 ### Fixed
+- Initialise loggers before anything else, to allow logging of all errors.
 ### Security
 
 ## [0.43.0] - 2017-04-17

--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -56,6 +56,9 @@ class BotManager
      */
     public function __construct(array $params)
     {
+        // Initialise logging before anything else, to allow errors to be logged.
+        $this->initLogging($params['logging'] ?? []);
+
         $this->params = new Params($params);
         $this->action = new Action($this->params->getScriptParam('a'));
 
@@ -117,9 +120,6 @@ class BotManager
      */
     public function run(): self
     {
-        // Initialise logging.
-        $this->initLogging();
-
         // Make sure this is a valid call.
         $this->validateSecret();
 
@@ -143,19 +143,17 @@ class BotManager
     /**
      * Initialise all loggers.
      *
+     * @param array $log_paths
+     *
      * @return \NPM\TelegramBotManager\BotManager
      * @throws \Exception
      */
-    public function initLogging(): self
+    public function initLogging(array $log_paths): self
     {
-        $logging = $this->params->getBotParam('logging');
-        if (is_array($logging)) {
-            /** @var array $logging */
-            foreach ($logging as $logger => $logfile) {
-                ('debug' === $logger) && TelegramLog::initDebugLog($logfile);
-                ('error' === $logger) && TelegramLog::initErrorLog($logfile);
-                ('update' === $logger) && TelegramLog::initUpdateLog($logfile);
-            }
+        foreach ($log_paths as $logger => $logfile) {
+            ('debug' === $logger) && TelegramLog::initDebugLog($logfile);
+            ('error' === $logger) && TelegramLog::initErrorLog($logfile);
+            ('update' === $logger) && TelegramLog::initUpdateLog($logfile);
         }
 
         return $this;

--- a/tests/TelegramBotManager/Tests/BotManagerTest.php
+++ b/tests/TelegramBotManager/Tests/BotManagerTest.php
@@ -108,19 +108,17 @@ class BotManagerTest extends \PHPUnit\Framework\TestCase
 
     public function testInitLogging()
     {
-        $botManager = new BotManager(array_merge(ParamsTest::$demo_vital_params, [
+        self::assertFalse(TelegramLog::isDebugLogActive());
+        self::assertFalse(TelegramLog::isErrorLogActive());
+        self::assertFalse(TelegramLog::isUpdateLogActive());
+
+        new BotManager(array_merge(ParamsTest::$demo_vital_params, [
             'logging' => [
                 'debug'  => '/tmp/php-telegram-bot-debuglog.log',
                 'error'  => '/tmp/php-telegram-bot-errorlog.log',
                 'update' => '/tmp/php-telegram-bot-updatelog.log',
             ],
         ]));
-
-        self::assertFalse(TelegramLog::isDebugLogActive());
-        self::assertFalse(TelegramLog::isErrorLogActive());
-        self::assertFalse(TelegramLog::isUpdateLogActive());
-
-        $botManager->initLogging();
 
         self::assertTrue(TelegramLog::isDebugLogActive());
         self::assertTrue(TelegramLog::isErrorLogActive());


### PR DESCRIPTION
When faced with the problem that some parameters have been set wrongly, there was no way to log the errors to the logger, as they hadn't been initialised yet.
Only option was to catch the exception and then do something with it.

Now, the core TelegramLog can be used to log any type of error :tada: