### PR TITLE
Loosen requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Execute commands via cron, using `cron` action and `g` parameter.
 ### Changed
 - Remodelled the config array to a more flexible structure.
+- `bot_username` and `secret` are no longer vital parameters.
 ### Deprecated
 ### Removed
 ### Fixed
 - Initialise loggers before anything else, to allow logging of all errors.
 ### Security
+- Enforce non-empty secret when using webhook.
 
 ## [0.43.0] - 2017-04-17
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "longman/telegram-bot": "^0.43",
+        "longman/telegram-bot": "^0.44",
         "allty/utils-ip": "dev-master"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "43bf32e5767ef8f4ce71f84ae233a3c3",
+    "content-hash": "00065e8f19ff2375ea717d4fdbc0368a",
     "packages": [
         {
             "name": "allty/utils-ip",
@@ -242,16 +242,16 @@
         },
         {
             "name": "longman/telegram-bot",
-            "version": "0.43.0",
+            "version": "0.44.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-telegram-bot/core.git",
-                "reference": "9d4d020fed98f4f0f57eb30c690c3a382b73ca26"
+                "reference": "e522050a5e2ac73a4c0fa47705896da0df37de3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/9d4d020fed98f4f0f57eb30c690c3a382b73ca26",
-                "reference": "9d4d020fed98f4f0f57eb30c690c3a382b73ca26",
+                "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/e522050a5e2ac73a4c0fa47705896da0df37de3a",
+                "reference": "e522050a5e2ac73a4c0fa47705896da0df37de3a",
                 "shasum": ""
             },
             "require": {
@@ -291,7 +291,7 @@
                 "bot",
                 "telegram"
             ],
-            "time": "2017-04-17T11:24:07+00:00"
+            "time": "2017-04-25T21:28:23+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -926,16 +926,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.1.1",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "bc433b7af27e0ab9b6b4c6d8ec918a493875f6bc"
+                "reference": "dc421f9ca5082a0c0cb04afb171c765f79add85b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/bc433b7af27e0ab9b6b4c6d8ec918a493875f6bc",
-                "reference": "bc433b7af27e0ab9b6b4c6d8ec918a493875f6bc",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/dc421f9ca5082a0c0cb04afb171c765f79add85b",
+                "reference": "dc421f9ca5082a0c0cb04afb171c765f79add85b",
                 "shasum": ""
             },
             "require": {
@@ -946,20 +946,21 @@
                 "phpunit/php-text-template": "^1.2",
                 "phpunit/php-token-stream": "^1.4.11 || ^2.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0",
-                "sebastian/environment": "^2.0",
-                "sebastian/version": "^2.0"
+                "sebastian/environment": "^3.0",
+                "sebastian/version": "^2.0",
+                "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
                 "ext-xdebug": "^2.5",
                 "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.1"
+                "ext-xdebug": "^2.5.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1.x-dev"
+                    "dev-master": "5.2.x-dev"
                 }
             },
             "autoload": {
@@ -985,7 +986,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-12T07:59:32+00:00"
+            "time": "2017-04-21T08:03:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1175,16 +1176,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.1.0",
+            "version": "6.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "2aa57c530381662b01c2cf705b03e8c12e918f1d"
+                "reference": "824d02024916525a36b2db21847a5ef91db9e4a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/2aa57c530381662b01c2cf705b03e8c12e918f1d",
-                "reference": "2aa57c530381662b01c2cf705b03e8c12e918f1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/824d02024916525a36b2db21847a5ef91db9e4a8",
+                "reference": "824d02024916525a36b2db21847a5ef91db9e4a8",
                 "shasum": ""
             },
             "require": {
@@ -1198,14 +1199,14 @@
                 "phar-io/version": "^1.0",
                 "php": "^7.0",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.0",
+                "phpunit/php-code-coverage": "^5.2",
                 "phpunit/php-file-iterator": "^1.4",
                 "phpunit/php-text-template": "^1.2",
                 "phpunit/php-timer": "^1.0.6",
                 "phpunit/phpunit-mock-objects": "^4.0",
                 "sebastian/comparator": "^2.0",
                 "sebastian/diff": "^1.2",
-                "sebastian/environment": "^2.0",
+                "sebastian/environment": "^3.0.1",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^1.1 || ^2.0",
                 "sebastian/object-enumerator": "^3.0.2",
@@ -1255,7 +1256,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-04-07T04:45:38+00:00"
+            "time": "2017-04-29T10:40:17+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
@@ -1479,28 +1480,28 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "2.0.0",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
+                "reference": "11e7710b7724d42c62249b0e9d3030240398949d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
-                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/11e7710b7724d42c62249b0e9d3030240398949d",
+                "reference": "11e7710b7724d42c62249b0e9d3030240398949d",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.0"
+                "phpunit/phpunit": "^6.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1525,7 +1526,7 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-11-26T07:53:53+00:00"
+            "time": "2017-04-21T14:40:32+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -1596,23 +1597,23 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "1.1.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4"
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bc37d50fea7d017d3d340f230811c9f1d7280af4",
-                "reference": "bc37d50fea7d017d3d340f230811c9f1d7280af4",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
+                "reference": "e8ba02eed7bbbb9e59e43dedd3dddeff4a56b0c4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-uopz": "*"
@@ -1620,7 +1621,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -1643,7 +1644,7 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12T03:26:01+00:00"
+            "time": "2017-04-27T15:39:26+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
@@ -1877,16 +1878,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "2.8.1",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d"
+                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
-                "reference": "d7cf0d894e8aa4c73712ee4a331cc1eaa37cdc7d",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
+                "reference": "f7dfecbee89d68ab475a6c9e17d22bc9b69aed97",
                 "shasum": ""
             },
             "require": {
@@ -1951,7 +1952,47 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-03-01T22:17:45+00:00"
+            "time": "2017-05-03T23:30:39+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "reference": "cb2f008f3f05af2893a87208fe6a6c4985483f8b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "time": "2017-04-07T12:08:54+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -17,8 +17,8 @@
         <ini name="error_reporting" value="-1" />
         <const name="PHPUNIT_TEST" value="true" />
         <const name="PHPUNIT_DB_HOST" value="127.0.0.1"/>
-        <const name="PHPUNIT_DB_NAME" value="telegrambot"/>
         <const name="PHPUNIT_DB_USER" value="root"/>
-        <const name="PHPUNIT_DB_PASS" value=""/>
+        <const name="PHPUNIT_DB_PASSWORD" value=""/>
+        <const name="PHPUNIT_DB_DATABASE" value="telegrambot"/>
     </php>
 </phpunit>

--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -173,7 +173,7 @@ class BotManager
         if ($force || 'cli' !== PHP_SAPI) {
             $secret     = $this->params->getBotParam('secret');
             $secret_get = $this->params->getScriptParam('s');
-            if ($secret_get !== $secret) {
+            if (!isset($secret, $secret_get) || $secret !== $secret_get) {
                 throw new InvalidAccessException('Invalid access');
             }
         }

--- a/src/Params.php
+++ b/src/Params.php
@@ -30,14 +30,14 @@ class Params
      */
     private static $valid_vital_bot_params = [
         'api_key',
-        'bot_username',
-        'secret',
     ];
 
     /**
      * @var array List of valid extra parameters that can be passed.
      */
     private static $valid_extra_bot_params = [
+        'bot_username',
+        'secret',
         'validate_request',
         'valid_ips',
         'webhook',
@@ -124,6 +124,11 @@ class Params
             }
 
             $this->bot_params[$vital_key] = $params[$vital_key];
+        }
+
+        // Special case, where secret MUST be defined if we have a webhook.
+        if (($params['webhook'] ?? null) && !($params['secret'] ?? null)) {
+            throw new InvalidParamsException('Some vital info is missing: secret');
         }
 
         // Set all extra params.

--- a/tests/TelegramBotManager/Tests/BotManagerTest.php
+++ b/tests/TelegramBotManager/Tests/BotManagerTest.php
@@ -37,9 +37,9 @@ class BotManagerTest extends \PHPUnit\Framework\TestCase
             'secret'       => 'super-secret',
             'mysql'        => [
                 'host'     => PHPUNIT_DB_HOST,
-                'database' => PHPUNIT_DB_NAME,
                 'user'     => PHPUNIT_DB_USER,
-                'password' => PHPUNIT_DB_PASS,
+                'password' => PHPUNIT_DB_PASSWORD,
+                'database' => PHPUNIT_DB_DATABASE,
             ],
         ];
     }
@@ -85,9 +85,12 @@ class BotManagerTest extends \PHPUnit\Framework\TestCase
      * @expectedException \NPM\TelegramBotManager\Exception\InvalidParamsException
      * @expectedExceptionMessage Some vital info is missing: secret
      */
-    public function testSomeVitalsFail()
+    public function testIncompleteVitalsFail()
     {
-        new BotManager(['api_key' => '12345:api_key', 'bot_username' => 'testbot']);
+        new BotManager([
+            'api_key' => '12345:api_key',
+            'webhook' => ['url' => 'https://web/hook.php'],
+        ]);
     }
 
     public function testVitalsSuccess()
@@ -102,7 +105,6 @@ class BotManagerTest extends \PHPUnit\Framework\TestCase
         $telegram = $bot->getTelegram();
 
         self::assertInstanceOf(Telegram::class, $telegram);
-        self::assertSame(ParamsTest::$demo_vital_params['bot_username'], $telegram->getBotUsername());
         self::assertSame(ParamsTest::$demo_vital_params['api_key'], $telegram->getApiKey());
     }
 
@@ -160,6 +162,7 @@ class BotManagerTest extends \PHPUnit\Framework\TestCase
     {
         $botManager = new BotManager(array_merge(ParamsTest::$demo_vital_params, [
             'webhook' => ['url' => 'https://web/hook.php'],
+            'secret'  => 'secret_12345',
         ]));
 
         TestHelpers::setObjectProperty(

--- a/tests/TelegramBotManager/Tests/ParamsTest.php
+++ b/tests/TelegramBotManager/Tests/ParamsTest.php
@@ -18,15 +18,15 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
      * @var array Demo vital parameters.
      */
     public static $demo_vital_params = [
-        'api_key'      => '12345:api_key',
-        'bot_username' => 'test_bot',
-        'secret'       => 'secret_12345',
+        'api_key' => '12345:api_key',
     ];
 
     /**
      * @var array Demo extra parameters.
      */
     public static $demo_extra_params = [
+        'bot_username'     => 'test_bot',
+        'secret'           => 'secret_12345',
         'validate_request' => true,
         'webhook'          => [
             'url'             => 'https://php.telegram.bot/manager.php',
@@ -75,7 +75,7 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
                 ],
             ],
         ],
-        'custom_input' => '{"some":"raw", "json":"update"}',
+        'custom_input'     => '{"some":"raw", "json":"update"}',
     ];
 
     public function setUp()
@@ -96,33 +96,18 @@ class ParamsTest extends \PHPUnit\Framework\TestCase
      */
     public function testConstructWithoutApiKey()
     {
-        new Params([
-            'bot_username' => 'test_bot',
-            'secret'       => 'secret_12345',
-        ]);
-    }
-
-    /**
-     * @expectedException \NPM\TelegramBotManager\Exception\InvalidParamsException
-     * @expectedExceptionMessage Some vital info is missing: bot_username
-     */
-    public function testConstructWithoutBotUsername()
-    {
-        new Params([
-            'api_key' => '12345:api_key',
-            'secret'  => 'secret_12345',
-        ]);
+        new Params([]);
     }
 
     /**
      * @expectedException \NPM\TelegramBotManager\Exception\InvalidParamsException
      * @expectedExceptionMessage Some vital info is missing: secret
      */
-    public function testConstructWithoutSecret()
+    public function testConstructWithWebhookWithoutSecret()
     {
         new Params([
-            'api_key'      => '12345:api_key',
-            'bot_username' => 'test_bot',
+            'api_key' => '12345:api_key',
+            'webhook' => self::$demo_extra_params['webhook'],
         ]);
     }
 


### PR DESCRIPTION
`bot_username` and `secret` are no longer vital parameters, as they are only required for certain functions.
Enforce non-empty secret when using webhook.

These changes reflect the latest changes in core.