### PR TITLE
[URGENT] BUGFIX: trim don't accept null argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,13 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 
 ## [Unreleased]
 ### Added
+- Custom output callback can be defined for getUpdates method.
 ### Changed
+- Default output of getUpdates method now shows the message type or query text, not the text message content.
 ### Deprecated
 ### Removed
 ### Fixed
+- GetUpdates method would crash if a non-text message was sent.
 ### Security
 
 ## [1.1.0] - 2017-05-23

--- a/README.md
+++ b/README.md
@@ -325,6 +325,43 @@ $bot = new BotManager([
 
 Now, the updates can be done either through the [browser](#via-browser) or [via CLI](#via-cli).
 
+#### Custom getUpdates output
+
+A callback can be defined, to override the default output when updates are handled via getUpdates.
+
+Example of the default output:
+```
+...
+2017-07-10 14:59:25 - Updates processed: 1
+123456: <text>
+2017-07-10 14:59:27 - Updates processed: 0
+2017-07-10 14:59:30 - Updates processed: 0
+2017-07-10 14:59:32 - Updates processed: 0
+2017-07-10 14:59:34 - Updates processed: 1
+123456: <photo>
+2017-07-10 14:59:36 - Updates processed: 0
+...
+```
+
+Using custom callback that must return a string:
+```php
+// In manager.php after $bot has been defined:
+$bot->setCustomGetUpdatesCallback(function (ServerResponse $get_updates_response) {
+    $results = array_filter((array) $get_updates_response->getResult());
+
+    return sprintf('There are %d update(s)' . PHP_EOL, count($results));
+});
+```
+output:
+```
+...
+There are 0 update(s)
+There are 0 update(s)
+There are 2 update(s)
+There are 1 update(s)
+...
+```
+
 ## Development
 
 When running live bot tests on a fork, you must enter the following environment variables to your [repository settings][travis-repository-settings] on travis-ci.org:

--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -478,25 +478,28 @@ class BotManager
      */
     protected function defaultGetUpdatesCallback($get_updates_response): string
     {
+        /** @var Entities\Update[] $results */
         $results = array_filter((array) $get_updates_response->getResult());
 
-        $output = date('Y-m-d H:i:s') . ' - ';
-        $output .= sprintf('Updates processed: %d' . PHP_EOL, count($results));
+        $output = sprintf(
+            '%s - Updates processed: %d' . PHP_EOL,
+            date('Y-m-d H:i:s'),
+            count($results)
+        );
 
-        /** @var Entities\Update $result */
         foreach ($results as $result) {
             $chat_id = 0;
-            $text    = 'Nothing';
+            $text    = '<n/a>';
 
             $update_content = $result->getUpdateContent();
             if ($update_content instanceof Entities\Message) {
                 $chat_id = $update_content->getFrom()->getId();
-                $text    = $update_content->getType();
+                $text    = sprintf('<%s>', $update_content->getType());
             } elseif ($update_content instanceof Entities\InlineQuery ||
                       $update_content instanceof Entities\ChosenInlineResult
             ) {
                 $chat_id = $update_content->getFrom()->getId();
-                $text    = $update_content->getQuery();
+                $text    = sprintf('<query> %s', $update_content->getQuery());
             }
 
             $output .= sprintf(

--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -462,6 +462,8 @@ class BotManager
                     $chat_id = $update_content->getFrom()->getId();
                     $text    = $update_content->getQuery();
                 }
+                
+                 $text = (is_null($text)?'':$text);
 
                 $output .= sprintf(
                     '%d: %s' . PHP_EOL,


### PR DESCRIPTION
when the user sends another type of request just like document or photo, $text going to null and trim() function throw PHP fatal error.