### PR TITLE
Bump core to 0.59.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
 
 script:
     - composer check-code
-    - if [[ "$CODECOV" == "1" ]]; then composer test-cov-live; else composer test; fi
+    - if [[ "$CODECOV" == "1" ]]; then composer test-cov; else composer test; fi
 
 after_success:
     - if [[ "$CODECOV" == "1" ]]; then composer test-cov-upload; fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ## [Unreleased]
 ### Added
 ### Changed
+- Upgraded dependencies and bumped core to version 0.59.0.
+- Code style is now PSR12.
 ### Deprecated
 ### Removed
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ It is possible however, to override the core version that this library requires:
 ```yaml
 "require": {
     "php-telegram-bot/telegram-bot-manager": "^1.4",
-    "longman/telegram-bot": "dev-develop as 0.57"
+    "longman/telegram-bot": "dev-develop as 0.59"
 }
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,13 @@
     ],
     "require": {
         "php": "^7.1",
-        "longman/telegram-bot": "^0.57",
-        "longman/ip-tools": "^1.2"
+        "longman/telegram-bot": "^0.59",
+        "longman/ip-tools": "^1.2",
+        "psr/log": "^1.1"
     },
     "require-dev": {
         "jakub-onderka/php-parallel-lint": "^1.0",
-        "phpunit/phpunit": "^7.5|^8.1",
+        "phpunit/phpunit": "^7.5|^8.2",
         "squizlabs/php_codesniffer": "^3.4"
     },
     "autoload": {
@@ -40,7 +41,7 @@
     "scripts": {
         "check-code": [
             "vendor/bin/parallel-lint . --exclude vendor",
-            "vendor/bin/phpcs --standard=psr2 src/ tests/ -snp --encoding=utf-8 --report-width=150"
+            "vendor/bin/phpcs -snp src/ tests/"
         ],
         "test": [
             "vendor/bin/phpunit --exclude-group live"
@@ -49,10 +50,10 @@
             "vendor/bin/phpunit"
         ],
         "test-cov": [
-            "vendor/bin/phpunit --coverage-clover=coverage.xml --exclude-group live"
+            "vendor/bin/phpunit --coverage-clover coverage.xml --exclude-group live"
         ],
         "test-cov-live": [
-            "vendor/bin/phpunit --coverage-clover=coverage.xml"
+            "vendor/bin/phpunit --coverage-clover coverage.xml"
         ],
         "test-cov-upload": [
             "curl -s https://codecov.io/bash | bash"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8ec2425675e9f09f6a5b52d1efea22e6",
+    "content-hash": "9a3d5f6d0e29206c1fbb8edb464fda40",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
@@ -124,33 +124,37 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.5.2",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "9f83dded91781a01c63574e387eaa769be769115"
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/9f83dded91781a01c63574e387eaa769be769115",
-                "reference": "9f83dded91781a01c63574e387eaa769be769115",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/239400de7a173fe9901b9ac7c06497751f00727a",
+                "reference": "239400de7a173fe9901b9ac7c06497751f00727a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.4.0",
                 "psr/http-message": "~1.0",
-                "ralouphie/getallheaders": "^2.0.5"
+                "ralouphie/getallheaders": "^2.0.5 || ^3.0.0"
             },
             "provide": {
                 "psr/http-message-implementation": "1.0"
             },
             "require-dev": {
+                "ext-zlib": "*",
                 "phpunit/phpunit": "~4.8.36 || ^5.7.27 || ^6.5.8"
+            },
+            "suggest": {
+                "zendframework/zend-httphandlerrunner": "Emit PSR-7 responses"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5-dev"
+                    "dev-master": "1.6-dev"
                 }
             },
             "autoload": {
@@ -187,7 +191,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2018-12-04T20:46:45+00:00"
+            "time": "2019-07-01T23:21:34+00:00"
         },
         {
             "name": "longman/ip-tools",
@@ -247,16 +251,16 @@
         },
         {
             "name": "longman/telegram-bot",
-            "version": "0.57.0",
+            "version": "0.59.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-telegram-bot/core.git",
-                "reference": "f2fe6e322d961153b82c39f699edbedb5311d328"
+                "reference": "80f626f2b1520c9b81831fa8cb7e55558c674341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/f2fe6e322d961153b82c39f699edbedb5311d328",
-                "reference": "f2fe6e322d961153b82c39f699edbedb5311d328",
+                "url": "https://api.github.com/repos/php-telegram-bot/core/zipball/80f626f2b1520c9b81831fa8cb7e55558c674341",
+                "reference": "80f626f2b1520c9b81831fa8cb7e55558c674341",
                 "shasum": ""
             },
             "require": {
@@ -266,7 +270,8 @@
                 "ext-pdo": "*",
                 "guzzlehttp/guzzle": "^6.3",
                 "monolog/monolog": "^1.24",
-                "php": "^5.5|^7.0"
+                "php": "^5.5|^7.0",
+                "psr/log": "^1.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8|^5.7|^6.5|^7.5|^8.1",
@@ -302,7 +307,7 @@
                 "bot",
                 "telegram"
             ],
-            "time": "2019-06-01T09:42:08+00:00"
+            "time": "2019-07-07T20:34:46+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -481,24 +486,24 @@
         },
         {
             "name": "ralouphie/getallheaders",
-            "version": "2.0.5",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa"
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
-                "reference": "5601c8a83fbba7ef674a7369456d12f1e0d0eafa",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3"
+                "php": ">=5.6"
             },
             "require-dev": {
-                "phpunit/phpunit": "~3.7.0",
-                "satooshi/php-coveralls": ">=1.0"
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
             },
             "type": "library",
             "autoload": {
@@ -517,7 +522,7 @@
                 }
             ],
             "description": "A polyfill for getallheaders.",
-            "time": "2016-02-11T07:05:27+00:00"
+            "time": "2019-03-08T08:55:37+00:00"
         }
     ],
     "packages-dev": [
@@ -929,16 +934,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
+                "reference": "1927e75f4ed19131ec9bcc3b002e07fb1173ee76",
                 "shasum": ""
             },
             "require": {
@@ -959,8 +964,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -988,7 +993,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2019-06-13T12:50:23+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1146,16 +1151,16 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059"
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b389aebe1b8b0578430bda0c7c95a829608e059",
-                "reference": "8b389aebe1b8b0578430bda0c7c95a829608e059",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/1038454804406b0b5f5f520358e78c1c2f71501e",
+                "reference": "1038454804406b0b5f5f520358e78c1c2f71501e",
                 "shasum": ""
             },
             "require": {
@@ -1191,20 +1196,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2019-02-20T10:12:59+00:00"
+            "time": "2019-06-07T04:22:29+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18"
+                "reference": "c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c99e3be9d3e85f60646f152f9002d46ed7770d18",
-                "reference": "c99e3be9d3e85f60646f152f9002d46ed7770d18",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c",
+                "reference": "c4a66b97f040e3e20b3aa2a243230a1c3a9f7c8c",
                 "shasum": ""
             },
             "require": {
@@ -1240,20 +1245,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2018-10-30T05:52:18+00:00"
+            "time": "2019-07-08T05:24:54+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "7.5.12",
+            "version": "7.5.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9ba59817745b0fe0c1a5a3032dfd4a6d2994ad1c"
+                "reference": "b9278591caa8630127f96c63b598712b699e671c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9ba59817745b0fe0c1a5a3032dfd4a6d2994ad1c",
-                "reference": "9ba59817745b0fe0c1a5a3032dfd4a6d2994ad1c",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b9278591caa8630127f96c63b598712b699e671c",
+                "reference": "b9278591caa8630127f96c63b598712b699e671c",
                 "shasum": ""
             },
             "require": {
@@ -1324,7 +1329,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2019-05-28T11:59:40+00:00"
+            "time": "2019-06-19T12:01:51+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -2003,16 +2008,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8"
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/1c42705be2b6c1de5904f8afacef5895cab44bf8",
-                "reference": "1c42705be2b6c1de5904f8afacef5895cab44bf8",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
+                "reference": "11336f6f84e16a720dae9d8e6ed5019efa85a0f9",
                 "shasum": ""
             },
             "require": {
@@ -2039,7 +2044,7 @@
                 }
             ],
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
-            "time": "2019-04-04T09:56:43+00:00"
+            "time": "2019-06-13T22:48:21+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset name="PHP Telegram Bot Manager">
+    <description>PHP Code Sniffer</description>
+
+    <arg name="colors"/>
+    <arg name="parallel" value="8"/>
+    <arg name="encoding" value="utf-8"/>
+    <arg name="report-width" value="150"/>
+
+    <rule ref="PSR12"/>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -27,7 +27,7 @@
     <php>
         <ini name="date.timezone" value="UTC"/>
         <ini name="error_reporting" value="-1"/>
-        <const name="PHPUNIT_TEST" value="true"/>
+        <const name="PHPUNIT_TESTSUITE" value="true"/>
         <const name="PHPUNIT_DB_HOST" value="127.0.0.1"/>
         <const name="PHPUNIT_DB_USER" value="root"/>
         <const name="PHPUNIT_DB_PASSWORD" value=""/>

--- a/src/BotManager.php
+++ b/src/BotManager.php
@@ -83,7 +83,7 @@ class BotManager
      */
     public static function inTest(): bool
     {
-        return \defined('PHPUNIT_TEST') && PHPUNIT_TEST === true;
+        return \defined('PHPUNIT_TESTSUITE') && PHPUNIT_TESTSUITE === true;
     }
 
     /**
@@ -162,6 +162,8 @@ class BotManager
      */
     public function initLogging(array $log_paths): self
     {
+        (defined('PHPUNIT_TESTSUITE') && PHPUNIT_TESTSUITE) || trigger_error(__METHOD__ . ' is deprecated and will be removed soon. Initialise with a preconfigured logger instance instead using "TelegramLog::initialize($logger)".', E_USER_DEPRECATED);
+
         foreach ($log_paths as $logger => $logfile) {
             ('debug' === $logger) && TelegramLog::initDebugLog($logfile);
             ('error' === $logger) && TelegramLog::initErrorLog($logfile);


### PR DESCRIPTION
- Bump core to 0.59.0 and update dependencies.
- Don't test with live API, proper testing should be done with mocks.
- PSR12 is now the coding standard.