### PR TITLE
Add and validate new secret_token webhook parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Exclamation symbols (:exclamation:) note something of importance e.g. breaking c
 ### Notes
 - [:ledger: View file changes][Unreleased]
 ### Added
+- Enforce `secret_token` webhook validation check.
 ### Changed
 ### Deprecated
 ### Removed

--- a/README.md
+++ b/README.md
@@ -211,6 +211,8 @@ $bot = new BotManager([
         'max_connections' => 20,
         // (array) List the types of updates you want your bot to receive.
         'allowed_updates' => ['message', 'edited_channel_post', 'callback_query'],
+        // (string) Secret token to validate webhook requests.
+        'secret_token'    => 'super_secret_token',
     ],
 
     // (bool) Only allow webhook access from valid Telegram API IPs.


### PR DESCRIPTION
| ?            |  !
|---           | ---
| Type         | feature
| BC Break     | no
| Fixed issues | n/a

#### Summary

Add new `secret_token` parameter for webhook and validate it on each request.