### PR TITLE
Update botmanager version in composer string

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installation and usage is pretty straight forward:
 ### Require this package with [Composer]
 
 ```bash
-composer require php-telegram-bot/telegram-bot-manager:^1.8
+composer require php-telegram-bot/telegram-bot-manager:^2.0.0
 ```
 
 **NOTE:** This will automatically also install [PHP Telegram Bot][github-tgbot-core] into your project (if it isn't already).
@@ -33,7 +33,7 @@ It is possible however, to override the core version that this library requires:
 
 ```yaml
 "require": {
-    "php-telegram-bot/telegram-bot-manager": "^1.8",
+    "php-telegram-bot/telegram-bot-manager": "^2.0.0",
     "longman/telegram-bot": "dev-master as 0.78"
 }
 ```


### PR DESCRIPTION
botmanager version 1.8 causes an error in composer, stating that it can't find this version. changing it to 2.0.0 lets composert install it normally.

<!--
Important:
If this pull request is not related to any issue and contains a new feature, please create an issue first for discussion.
https://github.com/php-telegram-bot/telegram-bot-manager/issues/new?template=Feature_Request.md

Make sure this pull request is pointed towards the "develop" branch and refers to any issue that it's related to!
-->

<!-- Fill in the relevant information below to help triage your pull request. -->

| ?            |  !
|---           | ---
| Type         | bug / feature / improvement
| BC Break     | yes / no
| Fixed issues | <!-- use #NUM format to reference an issue -->

#### Summary

<!-- Provide a summary of your change. -->
